### PR TITLE
Master

### DIFF
--- a/DSC Alarm.indigoPlugin/Contents/Server Plugin/Devices.xml
+++ b/DSC Alarm.indigoPlugin/Contents/Server Plugin/Devices.xml
@@ -2,16 +2,16 @@
 <Devices>
 	<Device type="custom" id="alarmZone">
 		<Name>Alarm Zone</Name>
-		<ConfigUI>			
+		<ConfigUI>
 			<Field id="zoneNumber" type="menu">
 				<Label>Zone Number:</Label>
 				<List class="self" method="getZoneList"/>
 			</Field>
-			
+
 			<Field id="space0" type="label">
 				<Label></Label>
 			</Field>
-			
+
 			￼<Field type="menu" id="zoneType" defaultValue="zoneTypeDoor">
 				<Label>Zone Type:</Label>
 				<List>
@@ -27,11 +27,11 @@
 			<Field id="zoneTypeHint" type="label" fontColor="darkgray" fontSize="small" alignWithControl="true">
 				<Label>The Zone Type has no effect at the moment.</Label>
 			</Field>
-			
+
 			<Field id="space1" type="label">
 				<Label></Label>
 			</Field>
-			
+
 			<Field id="zonePartition" type="menu" defaultValue="1">
 				<Label>Partition Number:</Label>
 				<List>
@@ -43,19 +43,19 @@
 					<Option value="6">6</Option>
 					<Option value="7">7</Option>
 					<Option value="8">8</Option>
-				</List>	
+				</List>
 			</Field>
 
 			<Field id="space2" type="label">
 				<Label></Label>
 			</Field>
-			
+
 			<Field type="checkbox" id="zoneLogChanges" defaultValue="1">
 				<Label>Log Changes:</Label>
 				<Description></Description>
 			</Field>
 		</ConfigUI>
-		
+
 		<UiDisplayStateId>state</UiDisplayStateId>
 		<States>
 			<State id="state">
@@ -63,7 +63,7 @@
 					<List>
 						<Option value="open">Open</Option>
 						<Option value="closed">Closed</Option>
-						<Option value="tripped">Tripped</Option>						
+						<Option value="tripped">Tripped</Option>
 					</List>
 				</ValueType>
 				<TriggerLabel>Zone State Changed</TriggerLabel>
@@ -87,7 +87,7 @@
 				<ValueType>String</ValueType>
 				<TriggerLabel>Last Changed Short State Changed</TriggerLabel>
 				<ControlPageLabel>Last Changed Short State</ControlPageLabel>
-			</State>			
+			</State>
 			<State id="LastChangedTimer">
 				<ValueType>Integer</ValueType>
 				<TriggerLabel>Last Changed Timer (mins.) Changed</TriggerLabel>
@@ -98,13 +98,13 @@
 
 		</States>
 	</Device>
-	
+
 	<Device type="custom" id="alarmKeypad">
 		<Name>Alarm Keypad</Name>
-		<ConfigUI>			
+		<ConfigUI>
 			<Field type="textfield" id="partitionName">
 				<Label>Partition Name:</Label>
-			</Field>			
+			</Field>
 			<Field id="space0" type="label">
 				<Label></Label>
 			</Field>
@@ -119,10 +119,10 @@
 					<Option value="6">6</Option>
 					<Option value="7">7</Option>
 					<Option value="8">8</Option>
-				</List>	
+				</List>
 			</Field>
 		</ConfigUI>
-		
+
 		<UiDisplayStateId>state</UiDisplayStateId>
 		<States>
 			<State id="state">
@@ -132,7 +132,7 @@
 						<Option value="exitDelay">Exit Delay</Option>
 						<Option value="armed">Armed</Option>
 						<Option value="entryDelay">Entry Delay</Option>
-						<Option value="tripped">Tripped</Option>						
+						<Option value="tripped">Tripped</Option>
 					</List>
 				</ValueType>
 				<TriggerLabel>Alarm State Changed</TriggerLabel>
@@ -147,7 +147,7 @@
 						<Option value="fire">Fire</Option>
 						<Option value="ambulance">Ambulance</Option>
 						<Option value="panic">Police</Option>
-						<Option value="duress">Duress</Option>						
+						<Option value="duress">Duress</Option>
 					</List>
 				</ValueType>
 				<TriggerLabel>Panic State Changed</TriggerLabel>
@@ -160,31 +160,31 @@
 					<List>
 						<Option value="disarmed">Disarmed</Option>
 						<Option value="stay">Armed Stay</Option>
-						<Option value="away">Armed Away</Option>						
+						<Option value="away">Armed Away</Option>
 					</List>
 				</ValueType>
 				<TriggerLabel>Armed State Changed</TriggerLabel>
 				<TriggerLabelPrefix>Armed State Changed to</TriggerLabelPrefix>
 				<ControlPageLabel>Current Armed State</ControlPageLabel>
 				<ControlPageLabelPrefix>Armed State is</ControlPageLabelPrefix>
-			</State>			
+			</State>
 			<State id="ReadyState">
 				<ValueType>
 					<List>
 						<Option value="ready">Ready</Option>
-						<Option value="notready">Not Ready</Option>						
+						<Option value="notready">Not Ready</Option>
 					</List>
 				</ValueType>
 				<TriggerLabel>Ready State Changed</TriggerLabel>
 				<TriggerLabelPrefix>Ready State Changed to</TriggerLabelPrefix>
 				<ControlPageLabel>Current Ready State</ControlPageLabel>
 				<ControlPageLabelPrefix>Ready State is</ControlPageLabelPrefix>
-			</State>			
+			</State>
 			<State id="KeypadChime">
 				<ValueType>
 					<List>
 						<Option value="enabled">Enabled</Option>
-						<Option value="disabled">Disabled</Option>					
+						<Option value="disabled">Disabled</Option>
 					</List>
 				</ValueType>
 				<TriggerLabel>Keypad Chime Changed</TriggerLabel>
@@ -201,7 +201,7 @@
 				<ValueType>String</ValueType>
 				<TriggerLabel>LCD Line 2</TriggerLabel>
 				<ControlPageLabel>LCD Line 2</ControlPageLabel>
-			</State>	
+			</State>
 			<State id="LEDReady">
 				<ValueType boolType="OnOff">Boolean</ValueType>
 				<TriggerLabel>Ready LED</TriggerLabel>
@@ -216,34 +216,34 @@
 				<ValueType boolType="OnOff">Boolean</ValueType>
 				<TriggerLabel>Trouble LED</TriggerLabel>
 				<ControlPageLabel>Trouble LED</ControlPageLabel>
-			</State>			
+			</State>
 			<State id="LEDMemory">
 				<ValueType boolType="OnOff">Boolean</ValueType>
 				<TriggerLabel>Memory LED</TriggerLabel>
 				<ControlPageLabel>Memory LED</ControlPageLabel>
-			</State>			
+			</State>
 			<State id="LEDBypass">
 				<ValueType boolType="OnOff">Boolean</ValueType>
 				<TriggerLabel>Bypass LED</TriggerLabel>
 				<ControlPageLabel>Bypass LED</ControlPageLabel>
-			</State>			
+			</State>
 		</States>
 	</Device>
-	
+
 
 	<Device type="custom" id="alarmZoneGroup">
 		<Name>Alarm Zone Group</Name>
-		<ConfigUI>	
+		<ConfigUI>
 			<Field id="note1" type="label" fontColor="darkgray" alignWithControl="true">
 				<Label>Hold the Command Key to Select Multiple Zones.</Label>
-			</Field>		
+			</Field>
 			<Field id='devList' type='list' rows="10">
 				<Label>Group Zones:</Label>
 				<List class="self" method="getZoneDevices"/>
 			</Field>
 
 		</ConfigUI>
-		
+
 		<UiDisplayStateId>state</UiDisplayStateId>
 		<States>
 			<State id="state">
@@ -251,14 +251,14 @@
 					<List>
 						<Option value="zoneOpen">A Member Zone Is Open</Option>
 						<Option value="allZonesClosed">All Zones Closed</Option>
-						<Option value="zoneTripped">A Member Zone Is Tripped</Option>						
+						<Option value="zoneTripped">A Member Zone Is Tripped</Option>
 					</List>
 				</ValueType>
 				<TriggerLabel>Zone Group State Changed</TriggerLabel>
 				<TriggerLabelPrefix>Zone Group State Changed to:</TriggerLabelPrefix>
 				<ControlPageLabel>Current Group State</ControlPageLabel>
 				<ControlPageLabelPrefix>Group State is</ControlPageLabelPrefix>
-			</State>		
+			</State>
 			<State id="AnyMemberLastChangedTimer">
 				<ValueType>Integer</ValueType>
 				<TriggerLabel>Minutes Since Any Zone's State Changed ...</TriggerLabel>
@@ -272,15 +272,25 @@
 				<TriggerLabelPrefix>Entire Group Changed Timer is</TriggerLabelPrefix>
 				<ControlPageLabel>Zone Group Timer</ControlPageLabel>
         		<ControlPageLabelPrefix>Zone Group Timer is</ControlPageLabelPrefix>
-			</State>			
+			</State>
+			<State id="AnyMemberLastChangedShort">
+				<ValueType>String</ValueType>
+				<TriggerLabel>Member Changed Short State Changed</TriggerLabel>
+				<ControlPageLabel>Member Changed Short State</ControlPageLabel>
+			</State>
+			<State id="EntireGroupLastChangedShort">
+				<ValueType>String</ValueType>
+				<TriggerLabel>Group Changed Short State Changed</TriggerLabel>
+				<ControlPageLabel>Group Changed Short State</ControlPageLabel>
+			</State>
 		</States>
-		
+
 	</Device>
-	
-	
+
+
 	<Device type="custom" id="alarmTemp">
 		<Name>DSC Thermostat</Name>
-		<ConfigUI>			
+		<ConfigUI>
 			<Field id="sensorNumber" type="menu">
 				<Label>Thermostat #:</Label>
 				<List>
@@ -288,19 +298,19 @@
 					<Option value="2">2</Option>
 					<Option value="3">3</Option>
 					<Option value="4">4</Option>
-				</List>	
+				</List>
 			</Field>
-			
+
 			<Field id="space0" type="label">
 				<Label></Label>
 			</Field>
-			
+
 			<Field type="checkbox" id="zoneLogChanges" defaultValue="1">
 				<Label>Log Changes:</Label>
 				<Description></Description>
 			</Field>
 		</ConfigUI>
-		
+
 		<UiDisplayStateId>temperatureInside</UiDisplayStateId>
 		<States>
 			<State id="temperatureInside">

--- a/DSC Alarm.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/DSC Alarm.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -1000,7 +1000,7 @@ class Plugin(indigo.PluginBase):
 
 		# Parse responses based on cmd value
 		#
-		
+
 		if cmd == '500':
 			self.mylogger.log(3, u"ACK for cmd %s." % dat)
 			self.cmdAck = dat
@@ -1498,7 +1498,7 @@ class Plugin(indigo.PluginBase):
 				self.sendEmailDisarm(u"Alarm Panel Disarmed by User %s%s. (Partition %d '%s')" % (user, keyu, partition, keyp))
 				if "DSC_Last_User_Disarm" in indigo.variables:
 					indigo.variable.updateValue("DSC_Last_User_Disarm", value = "User " + user + keyu)
-				
+
 				# self.trippedZoneList = []    #We do not want to delete list of tripped zones here
 				self.updateKeypad(partition, u'state', kAlarmStateDisarmed)
 				self.updateKeypad(partition, u'ArmedState', kAlarmArmedStateDisarmed)
@@ -1743,6 +1743,7 @@ class Plugin(indigo.PluginBase):
 		zoneGrp = indigo.devices[zoneGroupDevId]
 
 		zoneGrp.updateStateOnServer(key=u"AnyMemberLastChangedTimer", value=0)
+		zoneGrp.updateStateOnServer(key=u"AnyMemberLastChangedShort", value="0m")
 
 		newState = kZoneGroupStateClosed
 		for zoneId in self.zoneGroupList[zoneGroupDevId]:
@@ -1755,6 +1756,7 @@ class Plugin(indigo.PluginBase):
 
 		if zoneGrp.states[u'state'] != newState:
 			zoneGrp.updateStateOnServer(key=u"EntireGroupLastChangedTimer", value=0)
+			zoneGrp.updateStateOnServer(key=u"EntireGroupLastChangedShort", value="0m")
 			zoneGrp.updateStateOnServer(key=u"state", value=newState)
 
 
@@ -2233,8 +2235,10 @@ class Plugin(indigo.PluginBase):
 					zoneGroupDevice = indigo.devices[zoneGroupDeviceId]
 					tmr = zoneGroupDevice.states[u"AnyMemberLastChangedTimer"] + 1
 					zoneGroupDevice.updateStateOnServer(key=u"AnyMemberLastChangedTimer", value=tmr)
+					zoneGroupDevice.updateStateOnServer(key=u"AnyMemberLastChangedShort", value=self.getShortTime(tmr))
 					tmr = zoneGroupDevice.states[u"EntireGroupLastChangedTimer"] + 1
 					zoneGroupDevice.updateStateOnServer(key=u"EntireGroupLastChangedTimer", value=tmr)
+					zoneGroupDevice.updateStateOnServer(key=u"EntireGroupLastChangedShort", value=self.getShortTime(tmr))
 
 
 		self.closePort()

--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
-#DSC Alarm Plugin
+# DSC Alarm Plugin
 
-This plugin interfaces Indigo to a DSC PowerSeries alarm system using one of the interfaces below. It lets Indigo see the status of the entire alarm system. Triggers can be created for any alarm or zone change, actions can be created to Arm, Disarm, or trip the alarm. 
+This plugin interfaces Indigo to a DSC PowerSeries alarm system using one of the interfaces below. It lets Indigo see the status of the entire alarm system. Triggers can be created for any alarm or zone change, actions can be created to Arm, Disarm, or trip the alarm.
 
 The plugin also maintains timers to keep track of how long any doors and windows have been opened, as well as how long it's been since it's seen activity in certain areas. These timers can be used to turn off the HVAC system if the wife is airing out the house, or turn off lights in areas of the house that aren't occupied.
 
-##Information and Support
+## Information and Support
 Version 2.0 with changed from Monstergerm has been released.  Read the DSC plugin v2 Release Notes.pdf file for more information.
 
 For Installation and Information details please see this [forum post](http://forums.indigodomo.com/viewtopic.php?f=56&t=10287).
 
 If you need help, please post a topic in this  [user forum](http://forums.indigodomo.com/viewforum.php?f=56).
 
-##Downloading for use
+## Downloading for use
 
 If you are a user and just want to download and install the plugin, click on the "Clone or download" button and then "Download Zip" and it will download the plugin and readme file to a folder named "DSC-Alarm-master" in your Downloads directory. Once it's downloaded just open that folder and double-click on the "DSC Alarm.indigoPlugin" file to have the client install and enable it for you.
 
-##Contributing
+## Contributing
 
 If you want to contribute, just clone the repository in your account, make your changes, and issue a pull request. Make sure that you describe the change you're making thoroughly - this will help the repository managers accept your request more quickly.
 
-##Terms
+## Terms
 
 Perceptive Automation is hosting this repository and will do minimal management. Unless a pull request has no description or upon cursory observation has some obvious issue, pull requests will be accepted without any testing by us. We may choose to delegate commit privledges to other users at some point in the future.
 
-Perceptive Automation doesn't guarantee anything about this plugin - that this plugin works or does what the description above states, so use at your own risk. 
+Perceptive Automation doesn't guarantee anything about this plugin - that this plugin works or does what the description above states, so use at your own risk.
 
-##Plugin ID
+## Plugin ID
 
 Here's the plugin ID in case you need to programmatically restart the plugin:
 


### PR DESCRIPTION
Two new states for Zone Group devices:

AnyMemberLastChangedShort
EntireGroupLastChangedShort

These are exactly analogous to the similar states in regular Zone
devices and are useful on control pages e.g. to display how time since
_any_ door was opened or motion was detected in a multi-zone area.

p.s. my editor apparently like to strip superfluous white space.  There are fewer real changes than github reports.