### PR TITLE
v2022.0.6 with various updates

### DIFF
--- a/DSC Alarm.indigoPlugin/Contents/Info.plist
+++ b/DSC Alarm.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2022.0.2</string>
+	<string>2022.0.6</string>
 	<key>ServerApiVersion</key>
 	<string>3.0</string>
 	<key>IwsApiVersion</key>

--- a/DSC Alarm.indigoPlugin/Contents/Server Plugin/Actions.xml
+++ b/DSC Alarm.indigoPlugin/Contents/Server Plugin/Actions.xml
@@ -37,11 +37,10 @@
 		<Name>Trigger Panic Alarm</Name>
 		<CallbackMethod>methodPanicAlarm</CallbackMethod>
 		<ConfigUI>
-			<Field type="menu" id="panicAlarmType" defaultValue="4">
+			<Field type="menu" id="panicAlarmType" defaultValue="3">
 				<Label>Panic Type:</Label>
 				<List>
-					<Option value="4">Duress</Option>
-					<Option value="3">Panic</Option>
+					<Option value="3">Panic/Police</Option>
 					<Option value="2">Ambulance</Option>
 					<Option value="1">Fire</Option>
 				</List>
@@ -68,20 +67,20 @@
 				<Label>     Function Keys: 1(a), 2(b), 3(c), 4(d), 5(e)</Label>
 			</Field>
 			<Field id="label4" type="label">
-				<Label>     Arrow Keys: Left(&lt;), Right(&gt;), Both(=)</Label>
+				<Label>     Arrow Keys: Left(&#8592;), Right(&#8594;), Both(&#8592;&#8594;)</Label>
 			</Field>
 			<Field id="label5" type="label">
 				<Label>     Panic Keys: Fire(F), Ambulance(A), Panic(P)</Label>
 			</Field>
 			<Field id="label6" type="label">
-				<Label>     Long Keypress: Key followed by L.  ie. '2L' to hold 2.</Label>
+				<Label>     Long Keypress: Key followed by L  e.g. '2L' to hold 2.</Label>
 			</Field>	
 			<Field id="space1" type="label"><Label/></Field>
 			<Field id="label8" type="label">
 				<Label>Example:</Label>
 			</Field>
 			<Field id="label10" type="label">
-				<Label>     b236&gt;  would press function key 2, digits 236, right arrow. Special keys will not work with Envisalink.</Label>
+				<Label>     b236&#8594;  would press function key 2, digits 236, right arrow. Special keys will not work with Envisalink.</Label>
 			</Field>
 		</ConfigUI>
 	</Action>
@@ -157,7 +156,7 @@
 		<CallbackMethod>methodSyncTime</CallbackMethod>
 		<ConfigUI>
 			<Field id="label1" type="label">
-				<Label>This sets the time and date on the alarm to be the same as the Indigo host computer.</Label>
+				<Label>This sets the time and date on the DSC panel to be the same as the Indigo host computer.</Label>
 			</Field>
 			<Field id="space0" type="label"><Label/></Field>
 			<Field id="label2" type="label">

--- a/DSC Alarm.indigoPlugin/Contents/Server Plugin/Devices.xml
+++ b/DSC Alarm.indigoPlugin/Contents/Server Plugin/Devices.xml
@@ -133,7 +133,8 @@
 					<List>
 						<Option value="disarmed">Disarmed</Option>
 						<Option value="exitDelay">Exit Delay</Option>
-						<Option value="armed">Armed</Option>
+						<Option value="armedStay">Armed Stay</Option>
+						<Option value="armedAway">Armed Away</Option>
 						<Option value="entryDelay">Entry Delay</Option>
 						<Option value="tripped">Tripped</Option>						
 					</List>
@@ -149,7 +150,7 @@
 						<Option value="none">None</Option>
 						<Option value="fire">Fire</Option>
 						<Option value="ambulance">Ambulance</Option>
-						<Option value="panic">Police</Option>
+						<Option value="panic">Panic/Police</Option>
 						<Option value="duress">Duress</Option>						
 					</List>
 				</ValueType>

--- a/DSC Alarm.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
+++ b/DSC Alarm.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
@@ -30,11 +30,18 @@
 		<Label>(i.e. envisalink or 192.168.1.50; fixed IP is preferred)</Label>
 	</Field>
 
+	<Field id="TwoDS_Port" type="textfield" visibleBindingId="configInterface" visibleBindingValue="twods" defaultValue="4025">
+		<Label>Port:</Label>
+	</Field>
+	<Field id="TwoDS_PortLabel" type="label" visibleBindingId="configInterface" visibleBindingValue="twods" fontColor="darkgray" fontSize="small" alignWithControl="true">
+		<Label>(default port number = 4025)</Label>
+	</Field>
+
 	<Field id="TwoDS_Password" type="textfield" visibleBindingId="configInterface" visibleBindingValue="twods" secure="true">
 		<Label>Password:</Label>
 	</Field>
 	<Field id="snmpCommunityLabel" type="label" visibleBindingId="configInterface" visibleBindingValue="twods" fontColor="darkgray" fontSize="small" alignWithControl="true">
-		<Label>(default = user; max. 6 char.; except EVL-4 10 char.)</Label>
+		<Label>(default = user; max. 6 ASCII digits; except EVL-4 allows 10 digits)</Label>
 	</Field>
 
 
@@ -42,7 +49,7 @@
 		<Label>Disarm Code:</Label>
 	</Field>
 	<Field id="codeLabel" type="label" visibleBindingId="code" fontColor="darkgray" fontSize="small" alignWithControl="true">
-		<Label>This can be a password unique for Indigo Users, as long as it is programmed into the DSC panel.</Label>
+		<Label>This can be a 4-6 digit passcode unique for Indigo Users, as long as it is programmed into the DSC panel.</Label>
 	</Field>
 
 	<Field
@@ -274,10 +281,6 @@
 
 	<!-- Debug settings -->
 	<Field id="simpleSeparator2" type="separator"/>
-	<Field id="midLabel" type="label" fontColor="darkgray" fontSize="small" alignWithControl="true">
-		<Label>Set the level of information recorded to the Indigo log.</Label>
-	</Field>
-
     <Field id="logLevel" type="menu" defaultValue="20">
         <Label>Event Logging Level:</Label>
         <List>
@@ -289,5 +292,9 @@
             <Option value="50">Critical Errors Only</Option>
         </List>
     </Field>            
+	<Field id="midLabel" type="label" fontColor="darkgray" fontSize="small" alignWithControl="true">
+		<Label>Set the level of information recorded to the Indigo log.</Label>
+	</Field>
+
 
 </PluginConfig>


### PR DESCRIPTION
For better compatibility with the HomeKitLink-S plugin and the HomeKit app, removed Keypad device state:armed and replaced with state:armedAway and state:armedStay. If you have a trigger that relied on “Device State Changed > Keypad Device > Alarm State Changed to Armed” you need to reselect now one of the correct “ArmedStay” or “ArmedAway” states. All other triggers and events should work as before. This update will break arming with the HKL-S plugin v0.3.21 via the HomeKit app until it is updated.
Improved timing of bypassing multiple zones in forced arm actions. Let me know if you encounter any keybus buffer overruns.
Optimized handling of keypad panic, fire and ambulance alarms.
Added option to specify custom ports for Envisalink.
Fixed minor issue with custom icon settings.
Removed Python 2 code.
